### PR TITLE
Changes for applying morphological conditions per species

### DIFF
--- a/conf/cutout_filters/default.yaml
+++ b/conf/cutout_filters/default.yaml
@@ -1,64 +1,250 @@
 # Settings
 
-total_images: 3
+total_images: 10
 
 background_fov_cm2: 7500 # bbot images, Assumed real-world field of view for backgrounds (in cm²)
 # background_fov_cm2: 3000  # unsplash images Assumed real-world field of view for backgrounds (in cm²)
 resize_factor: 0.25
 
 cuts_n_image: # Number of cutouts per image
-  min: 500
-  max: 1500
+  min: 1
+  max: 2
 
 reuse_cutouts: true  # Whether to allow reusing cutouts in multiple images
 min_visibility: 0.0  # Minimum visibility ratio required for the new cutout
+
 morphological:
+  # These filters are applied uniformly to every species (not per-species).
+  # For per-species filters (season, year, estimated_bbox_area_cm2, num_components,
+  # day_range) see category.species_filters below.
   non_target_weed:  # Querying for non_target_weed == false
   non_target_weed_pred_conf:
     min:
     max:  # Confidence must be between 0.5 and 1.0
-  # Filter settings for morphological properties under "cutout_props"
+
   is_primary: true
   extends_border: false
   validated: null # suggested database has no "Validated" column
-  
-  bbox_area_cm2:  # Area range in cm2
-    default:
-      min: 10
-      max: 1000
-    common_name_ranges: # applies to specific common names, use default if not specified here but in the common_name list
-      Mustards:
-        min: 10
-        max: 1000
-    
-    
-    # very_small: [0, 0.1]
-    # small: [0.1, 1]
-    # medium: [1, 10]
-    # medium_large: [10, 100]
-    # large: [100, 1000]
-    # very_large: [1000, 1000000]
-  
+
   blur_effect:  # Blur effect threshold
-    min: 
-    max: 
-  num_components: # Number of components range
     min:
     max:
 
+# Per-species filters.
+#
+# Each key under `species_filters` is a category_common_name to include. Every
+# field below follows one rule: leave it blank/empty and NO condition is
+# applied for that field for that species (i.e. it goes through unfiltered on
+# that dimension). There is no implicit shared "default" fallback -- blank
+# always means unrestricted, not "use some default range".
+#
+# is_primary / extends_border are the ONE exception to that rule, since they
+# default to the *global* morphological.is_primary / morphological.extends_border
+# value above rather than to "unrestricted":
+#   - blank      -> inherit the global value (same behavior as every other
+#                    species that doesn't override it)
+#   - true/false -> override the global value for this species only
+#   - "any"      -> explicit opt-out: no filter at all for this species,
+#                    even while the global filter stays active for everyone
+#                    else
+#
+# estimated_bbox_area_cm2: pick ONE mode, never both:
+#   - {min, max}   -> literal absolute cm^2 range
+#   - {percentile} -> keep rows above this percentile (e.g. 75 = keep the top
+#                     25% by estimated_bbox_area_cm2), computed independently
+#                     per matching season, AFTER season/year/num_components/
+#                     day_range have already narrowed that season's rows.
+#
+# day_range: pick ONE mode, or leave entirely blank for no date filtering.
+# All offsets are always relative to that SPECIFIC season's own min/max
+# datetime (computed live per season -- never a fixed calendar date), so
+# nothing here ever needs to be precomputed by hand:
+#   - last_days: N            -> [max_dt - N days, max_dt]
+#   - first_days: N           -> [min_dt, min_dt + N days]
+#   - trim_days: {start, end} -> [min_dt + start days, max_dt - end days]
+#     (either side of trim_days may be 0 to only trim the other end)
+#
+# When `season` is left blank (all seasons), day_range and the
+# estimated_bbox_area_cm2 percentile are each computed independently per
+# matching season -- never combined into one cross-season window/threshold.
 category:
-  # Filter settings for category attributes
-  common_name:
-    - oats
-    - cereal rye
-    - Crimson clover
-    - red clover
-    - winter pea
-    - hairy vetch
-    - Black Oats
-    - Winter Wheat
-    - Mustards
-    
+  species_filters:
+    oats:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    cereal rye:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    crimson clover:
+      season: [cover_crops_2023_2024]
+      year:
+      is_primary: any
+      extends_border: any
+      estimated_bbox_area_cm2:
+        min:
+        max:
+        percentile: 75
+      num_components:
+        min: 1
+        max: 20
+      day_range:
+        last_days: 2
+        first_days:
+        trim_days:
+          start:
+          end:
+    red clover:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    winter pea:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    hairy vetch:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    black oats:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    winter wheat:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+    mustards:
+      season:
+      year:
+      is_primary:
+      extends_border:
+      estimated_bbox_area_cm2:
+        min: 10
+        max: 1000
+        percentile:
+      num_components:
+        min:
+        max:
+      day_range:
+        last_days:
+        first_days:
+        trim_days:
+          start:
+          end:
+
+common_name_weights:
+    crimson clover: 1.0  # clover
+    red clover: 0.0    # clover
+    winter pea: 0.0     # peas
+    hairy vetch: 0.0   # vetch
+    mustards: 0.0        # brassicas
+    black oats: 0.0     # Grass
+    oats: 0.0            # Grass
+    cereal rye: 0.0      # Grass
+    winter wheat: 0.0    # Grass
+
+
+
     # - Barley
     # - Barnyardgrass
     # - Broadleaf Signalgrass
@@ -104,14 +290,3 @@ category:
     # - Winter Pea
     # - Winter Wheat
     # - Yellow Foxtail
-    
-common_name_weights:
-    crimson clover: 0.15  # clover
-    red clover: 0.15      # clover
-    winter pea: 0.15      # peas
-    hairy vetch: 0.15     # vetch
-    mustards: 0.15        # brassicas
-    black oats: 0.075      # Grass
-    oats: 0.075            # Grass
-    cereal rye: 0.075      # Grass
-    winter wheat: 0.075    # Grass

--- a/src/analyze/analyze_cutouts.py
+++ b/src/analyze/analyze_cutouts.py
@@ -19,7 +19,7 @@ class CutoutAnalyzer():
         self.db_path = str(cfg.paths.sql_database)
 
         # Extract list of common names
-        species_list = list(set(name.lower() for name in cfg.cutout_filters.category.common_name))
+        species_list = list(set(name.lower() for name in cfg.cutout_filters.category.species_filters.keys()))
         sorted_species = sorted(species_list, key=lambda s: s.lower())
 
         # KEEP TRACK OF NUMBER OF CUTOUTS
@@ -220,9 +220,9 @@ def main(cfg: DictConfig, report: PDFDrafter) -> None:
     directory_for_graphs_of_specified_cutouts = "specified"
     directory_for_graphs_of_storages = 'storage_location'
 
-    if not cfg.cutout_filters.category.common_name:
+    if not cfg.cutout_filters.category.species_filters:
         log.error("No species specified for analysis")
-        log.error("Species can be specified in cutout_filters under common_name")
+        log.error("Species can be specified in cutout_filters under category.species_filters")
         return
 
     # Graph all species specified in config
@@ -238,7 +238,7 @@ def main(cfg: DictConfig, report: PDFDrafter) -> None:
     heading = "Analysis of Cutouts"
 
     # Description
-    species_list = list(set(name.lower() for name in cfg.cutout_filters.category.common_name))
+    species_list = list(set(name.lower() for name in cfg.cutout_filters.category.species_filters.keys()))
     species_list = add_grammar_and_capitalization_to_list(species_list)
     description = f"The following section is a report of the {species_list} in the database. The aim is to display the metadata of all cutouts vs cutouts you specified in your configuration"
 

--- a/src/analyze/analyze_preprocessed_cutouts.py
+++ b/src/analyze/analyze_preprocessed_cutouts.py
@@ -65,7 +65,7 @@ class PreprocessAnalyzer():
         for species, process_param_pairs in species_processes_dictionary.items():
 
             if species not in self.cutouts_indexed_by_species:
-                log.error(f"Requested analysis for a species: {species} not in recipe (not requested in category.common_name). Skipping")
+                log.error(f"Requested analysis for a species: {species} not in recipe (not requested in category.species_filters). Skipping")
                 continue
 
             # Get list of cutouts to add to report

--- a/src/create_recipes.py
+++ b/src/create_recipes.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Any
 from collections import defaultdict
 from omegaconf import DictConfig
 from tqdm import tqdm
-from utils.sql3_query import SQLiteQueryHandler
+from utils.sql3_query import SpeciesFilterQueryEngine
 
 log = logging.getLogger(__name__)
   
@@ -330,13 +330,12 @@ def main(cfg: DictConfig) -> None:
     """
     log.info("Starting recipe creation process.")  # Log the start of the process
 
-    query_handler = SQLiteQueryHandler(cfg)
-    query_handler.add_conditions()
-    rows, columns = query_handler.execute_query()
-    log.info(f"Retrieved {len(rows)} documents from the database.")
-    query_handler.close()
-    # Convert the rows to a list of dictionaries.
-    documents = [dict(zip(columns, row)) for row in rows]
+    query_engine = SpeciesFilterQueryEngine(cfg)
+    try:
+        documents = query_engine.fetch_all()
+    finally:
+        query_engine.close()
+    log.info(f"Retrieved {len(documents)} documents from the database.")
     # Ensure each document has an _id field.
     for doc in documents:
         if "_id" not in doc:

--- a/src/preprocess_cutouts.py
+++ b/src/preprocess_cutouts.py
@@ -20,7 +20,7 @@ class CutoutProcessor():
         self.num_workers = cfg.preprocess_cutouts.num_workers
 
         self.common_names = [
-            name.upper() for name in self.cfg.cutout_filters.category.common_name
+            name.upper() for name in self.cfg.cutout_filters.category.species_filters.keys()
         ]
         db_path = str(cfg.paths.sql_database)
 
@@ -223,7 +223,7 @@ def invert_and_check_species_preprocess_dictionary(preprocess_cutouts: dict[str,
 
             else:
                 log.warning(
-                    f"Requested preprocessing for {species_upper} but did not specify in cfg.cutout_filters.category.common_name"
+                    f"Requested preprocessing for {species_upper} but did not specify in cfg.cutout_filters.category.species_filters"
                 )
                 log.warning("Skipping this species")
 

--- a/src/utils/pdf.py
+++ b/src/utils/pdf.py
@@ -18,7 +18,7 @@ class PDFDrafter():
         self.cfg = cfg
 
         # Extract species and sort them alphabetically, ignore duplicates
-        species_list = list(set(name.lower() for name in cfg.cutout_filters.category.common_name))
+        species_list = list(set(name.lower() for name in cfg.cutout_filters.category.species_filters.keys()))
         self.sorted_species = sorted(species_list, key=lambda s: s.lower())
 
         # Set up canvas/pdf

--- a/src/utils/sql3_query.py
+++ b/src/utils/sql3_query.py
@@ -1,266 +1,346 @@
-import sqlite3
 import logging
-from datetime import datetime
-import hydra
-import omegaconf
+import sqlite3
+from datetime import timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
 from omegaconf import DictConfig
+
+from utils.datetime_utils import parse_datetime, percentile
 
 log = logging.getLogger(__name__)
 
 
-class SQLiteQueryHandler:
+class SpeciesFilterQueryEngine:
     """
-    A class to build and execute SQL queries dynamically.
-    
-    This class lets you add conditions, build the query string, execute it,
-    and then format or save the results.
+    Builds and executes per-species filtered queries against the cutouts
+    table, driven by `cutout_filters.category.species_filters` in
+    conf/cutout_filters/default.yaml.
+
+    Unlike a single combined query for every species, this loops per
+    species and, within a species, per season -- because the `day_range`
+    filter and the `estimated_bbox_area_cm2` percentile mode both need a
+    per-species, per-season MIN/MAX(datetime) baseline that has to be
+    computed in Python (the `datetime` column mixes EXIF-style and ISO
+    timestamp formats, so it can't be reliably compared/aggregated in raw
+    SQL) before they can be turned into a filter at all.
+
+    Per-species filter order (fixed, not configurable):
+      1. category_common_name + season + year -- in SQL. This is the ONLY
+         thing that defines the candidate pool used to compute the
+         day_range baseline below -- is_primary, extends_border,
+         blur_effect, non_target_weed, non_target_weed_pred_conf,
+         num_components, and estimated_bbox_area_cm2 must never skew where
+         that window sits, since none of them are date-defining. (Before
+         this was fixed, is_primary/extends_border were applied in this
+         same SQL query, which could anchor the day_range window to an
+         artificially sparse subset -- see project conversation for the
+         concrete case that surfaced this.)
+      2. day_range window, if set -- computed in Python from the step-1
+         rows' own MIN/MAX(datetime).
+      3. is_primary / extends_border, applied in Python to the step-2 rows.
+         Each defaults to the global `morphological.is_primary` /
+         `extends_border` value, but a species may override it: blank
+         (unset) inherits the global value, True/False overrides it for
+         that species only, and the literal string "any" explicitly opts
+         that species out of the filter entirely (even while it's still
+         active for every other species). blur_effect/non_target_weed/
+         non_target_weed_pred_conf remain purely global (no per-species
+         override), applied here too.
+      4. num_components range, if set.
+      5. estimated_bbox_area_cm2, if set -- either an absolute {min,max}
+         range, or a percentile threshold computed over the step-4 rows
+         for that season.
+
+    The sqlite connection is opened strictly read-only -- this class never
+    writes to the database.
     """
 
     def __init__(self, cfg: DictConfig) -> None:
-        """
-        Initialize the QueryBuilder with a SQLite database file and target table.
-        
-        Args:
-            db_path (str): Path to the SQLite database file.
-            table_name (str): Name of the table on which to run queries.
-        """
+        self.cfg = cfg
         self.db_path = cfg.paths.sql_database
         self.table_name = cfg.sqlite3.cutouts
-        self.connection = sqlite3.connect(self.db_path)
-        self.cursor = self.connection.cursor()
-        self.conditions = []  # List to hold SQL conditions (strings).
-        self.params = []      # List to hold values corresponding to the conditions.
-        log.info("Connected to database: %s", self.db_path)
-        self.filter = cfg.cutout_filters
-
-    def add_conditions(self) -> None:
-        """
-        Add conditions to the query based on the configuration filters.
-        """
-        self.add_morphological_condition()
-        self.add_category_condition()
-        self.add_non_target_weed_condition()
-        self.add_validated_filter()
-    
-    def add_condition(self, column: str, operator: str, value) -> None:
-        """
-        Add a condition to the query.
-
-        This method appends a condition (with a parameter placeholder) to the list
-        of conditions and saves the parameter value. For example:
-            add_condition("age", ">", 30)
-        will later add "age > ?" to the query and 30 as a parameter.
-        
-        Args:
-            column (str): The column name.
-            operator (str): SQL operator (e.g., '=', '>', '<', 'LIKE', etc.).
-            value: The value to compare.
-        """
-        condition = f"{column} {operator} ?"
-        self.conditions.append(condition)
-        self.params.append(value)
-        log.info("Added condition: %s with value: %s", condition, value)
-
-
-    def build_query(self) -> str:
-        """
-        Construct the SQL query string from the base query and any conditions.
-        
-        Returns:
-            str: The full SQL query.
-        """
-        base_query = f"SELECT * FROM {self.table_name}"
-        if self.conditions:
-            where_clause = " AND ".join(self.conditions)
-            query = f"{base_query} WHERE {where_clause}"
-        else:
-            query = base_query
-        log.info("Built query: %s", query)
-        return query
-
-    def execute_query(self) -> tuple[list, list]:
-        """
-        Execute the constructed SQL query and return the results.
-        
-        Returns:
-            tuple: A tuple containing the list of rows and a list of column names.
-        """
-        query = self.build_query()
-        start_time = datetime.now()
-        try:
-            log.info("Executing query: %s with parameters: %s", query, self.params)
-            self.cursor.execute(query, self.params)
-            rows = self.cursor.fetchall()
-            col_names = [desc[0] for desc in self.cursor.description]
-            log.info("Query executed in: %s", datetime.now() - start_time)
-            return rows, col_names
-        except sqlite3.Error as e:
-            log.error("Query execution failed: %s", e)
-            return [], []
-
+        self.conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+        self.conn.row_factory = sqlite3.Row
+        self.species_filters = cfg.cutout_filters.category.species_filters
+        self.morphological = cfg.cutout_filters.morphological
 
     def close(self) -> None:
-        """Commit changes (if any) and close the database connection."""
-        self.connection.commit()
-        self.connection.close()
-        log.info("Database connection closed.")
+        self.conn.close()
 
-    
-    def add_bbox_area_condition(self) -> None:
-        bbox_config = self.filter.morphological.get('bbox_area_cm2')
-        if not bbox_config:
-            return
+    # ---- global (uniform by default, per-species overridable) morphological filters ----
+    # Applied in Python, AFTER the day_range window (see class docstring for
+    # why) -- never folded into the SQL fetch that defines the day_range
+    # baseline.
 
-        # Get default values
-        default_range = bbox_config.get('default', {})
-        default_min = default_range.get('min', 0)
-        default_max = default_range.get('max', float('inf'))
-
-        # Check for common name specific overrides
-        cn_ranges = bbox_config.get('common_name_ranges', {})
-
-        if cn_ranges:
-            conditions = []
-            parameters = []
-
-            # For each common name, add a sub-condition
-            for cn, range_vals in cn_ranges.items():
-                cn_lower = cn.lower().strip()
-                min_val = range_vals.get('min', default_min)
-                max_val = range_vals.get('max', default_max)
-                conditions.append("(LOWER(trim(category_common_name)) = ? AND estimated_bbox_area_cm2 >= ? AND estimated_bbox_area_cm2 <= ?)")
-                parameters.extend([cn_lower, min_val, max_val])
-
-            # For records whose common name is not specified in the overrides, apply the default range.
-            placeholders = ", ".join("?" for _ in cn_ranges.keys())
-            default_condition = f"(LOWER(trim(category_common_name)) NOT IN ({placeholders}) AND estimated_bbox_area_cm2 >= ? AND estimated_bbox_area_cm2 <= ?)"
-            # Add the lower-cased common names to the parameters.
-            parameters.extend([cn.lower().strip() for cn in cn_ranges.keys()])
-            parameters.extend([default_min, default_max])
-            conditions.append(default_condition)
-
-            # Combine all sub-conditions with OR.
-            full_condition = "(" + " OR ".join(conditions) + ")"
-            self.conditions.append(full_condition)
-            self.params.extend(parameters)
-        else:
-            # If no specific common name ranges, fall back to default
-            self.add_condition("estimated_bbox_area_cm2", ">=", default_min)
-            self.add_condition("estimated_bbox_area_cm2", "<=", default_max)
-
-    def add_validated_filter(self) -> None:
+    @staticmethod
+    def _resolve_species_override(species_value: Any, global_value: Any) -> Optional[bool]:
+        """Resolve is_primary/extends_border for one species:
+          - blank (None)      -> inherit the global morphological value
+          - True / False      -> override for this species only
+          - the literal string "any" (case-insensitive) -> explicit opt-out:
+            no filter for this species, even if the global filter is active
+            for everyone else.
         """
-        Add a filter for the 'validated' column.
-        """
-        # Assume the filter value is provided in the configuration under self.filter.validated
-        validated_value = self.filter.get("validated", None)
-        if validated_value is not None:
-            self.add_condition("validated", "=", validated_value)
-            
-    def add_range_filter(self, morph: dict, key: str, column: str) -> None:
-        """
-        Add a range filter to the query.
-        
-        Args:
-            morph (dict): The morphological filter dictionary.
-            key (str): The key in the morphological filter dictionary.
-            column (str): The column name in the database.
-        """
-        if key in morph and morph[key]:
-            min_val = morph[key].get('min', 0)
-            max_val = morph[key].get('max', float('inf'))
-            if min_val is not None or max_val is not None:
-                if min_val != float('inf') or min_val is not None:
-                    self.add_condition(column, ">=", min_val)
-                if max_val != float('inf') or max_val is not None:
-                    self.add_condition(column, "<=", max_val)
-    
-    def add_morphological_condition(self) -> None:
-        """
-        Add morphological filters from the configuration to the query.
-        """
-        morph = self.filter.morphological
+        if species_value is None:
+            return global_value
+        if isinstance(species_value, str) and species_value.strip().lower() == "any":
+            return None
+        return species_value
 
-        # Handle area filter
-        # if 'bbox_area_cm2' in morph and morph.bbox_area_cm2:
-        #     self.add_condition("json_extract(cutout_props, '$.bbox_area_cm2')", ">=", morph.bbox_area_cm2.get('min', 0))
-        #     self.add_condition("json_extract(cutout_props, '$.bbox_area_cm2')", "<=", morph.bbox_area_cm2.get('max', float('inf')))
-        self.add_bbox_area_condition()
-        # Handle extends_border filter
-        if morph.get('extends_border') is not None:
-            self.add_condition("extends_border", "=", morph.extends_border)
+    def _apply_global_morphological_filters(
+        self, rows: List[sqlite3.Row], is_primary: Optional[bool], extends_border: Optional[bool]
+    ) -> List[sqlite3.Row]:
+        m = self.morphological
+        non_target_weed = m.get("non_target_weed")
+        blur = m.get("blur_effect") or {}
+        blur_min, blur_max = blur.get("min"), blur.get("max")
+        ntw_conf = m.get("non_target_weed_pred_conf") or {}
+        ntw_min, ntw_max = ntw_conf.get("min"), ntw_conf.get("max")
 
-        # Handle is_primary filter
-        if morph.get('is_primary') is not None:
-            self.add_condition("is_primary", "=", morph.is_primary)
+        if m.get("validated") is not None:
+            log.warning(
+                "morphological.validated is set (%r) but this database copy has no "
+                "`validated` column -- ignoring this filter.", m.get("validated")
+            )
 
-        # Handle blur_effect filter
-        self.add_range_filter(morph, 'blur_effect', 'blur_effect')
+        if all(v is None for v in (is_primary, extends_border, non_target_weed, blur_min, blur_max, ntw_min, ntw_max)):
+            return rows
 
-        # Handle num_components filter
-        self.add_range_filter(morph, 'num_components', 'num_components')
+        def keep(row: sqlite3.Row) -> bool:
+            if is_primary is not None and row["is_primary"] != is_primary:
+                return False
+            if extends_border is not None and row["extends_border"] != extends_border:
+                return False
+            if non_target_weed is not None and row["non_target_weed"] != non_target_weed:
+                return False
+            if blur_min is not None and (row["blur_effect"] is None or row["blur_effect"] < blur_min):
+                return False
+            if blur_max is not None and (row["blur_effect"] is None or row["blur_effect"] > blur_max):
+                return False
+            if ntw_min is not None and (row["non_target_weed_pred_conf"] is None or row["non_target_weed_pred_conf"] < ntw_min):
+                return False
+            if ntw_max is not None and (row["non_target_weed_pred_conf"] is None or row["non_target_weed_pred_conf"] > ntw_max):
+                return False
+            return True
 
-    def add_category_condition(self) -> None:
-        """
-        Add category filters from the configuration to the query.
-        Handle cases where category fields can be exact values or lists.
-        """
-        category = self.filter.category
-        for key, value in category.items():
-            # Only process if there is a value provided.
-            if value:
-                if key == 'common_name':
-                    # Handle common_name case-insensitively.
-                    # If the value is a list or ListConfig, process it as a list.
-                    if isinstance(value, (list, omegaconf.listconfig.ListConfig)):
-                        names = list(value)  # Convert to a regular list if necessary.
-                        # Build placeholders for each name.
-                        placeholders = ", ".join("?" for _ in names)
-                        # Construct the condition:
-                        # LOWER(json_extract(category, '$.common_name')) IN (?, ?, ...)
-                        condition = f"LOWER(trim(category_common_name)) IN ({placeholders})"
-                        # condition = "LOWER(trim(json_extract(category, '$.common_name'))) = ?"
-                        self.conditions.append(condition)
-                        # Append the lower-cased names to the parameters.
-                        self.params.extend([name.lower().strip() for name in names])
-                    else:
-                        # If value is a single string, use an equality check.
-                        # condition = "LOWER(json_extract(category, '$.common_name')) = ?"
-                        condition = "LOWER(trim(category_common_name)) = ?"
-                        self.conditions.append(condition)
-                        self.params.append(value.lower().strip())
-                else:
-                    # For other category keys, apply a simple equality filter.
-                    condition = f"category_{key} = ?"
-                    self.conditions.append(condition)
-                    self.params.append(value)
-    def add_non_target_weed_condition(self) -> None:
-        """
-        Add filters for non-target weeds from the configuration to the query.
-        """
-        non_target_weed = self.filter.morphological.non_target_weed
-        non_target_weed_pred_conf = self.filter.morphological.non_target_weed_pred_conf
+        return [row for row in rows if keep(row)]
 
-        # Handle non_target_weed filters either True or False
-        if non_target_weed is not None:
-            self.add_condition("non_target_weed", "=", non_target_weed)
+    # ---- per-species helpers ----
 
-        # Handle non_target_weed_pred_conf filter which has a min and max value
-        if non_target_weed_pred_conf.min or non_target_weed_pred_conf.max:
-            min_conf = non_target_weed_pred_conf.get('min', 0.0)
-            max_conf = non_target_weed_pred_conf.get('max', 1.0)
-            self.add_condition("non_target_weed_pred_conf", ">=", min_conf)
-            self.add_condition("non_target_weed_pred_conf", "<=", max_conf)
+    def _seasons_for_species(self, common_name: str) -> List[str]:
+        rows = self.conn.execute(
+            f"SELECT DISTINCT season FROM {self.table_name} "
+            "WHERE LOWER(TRIM(category_common_name)) = ?",
+            (common_name.lower().strip(),),
+        ).fetchall()
+        return [r["season"] for r in rows]
 
-@hydra.main(version_base="1.2", config_path="../../conf", config_name="config")
-def main(cfg: DictConfig) -> None:
-    
-    # Usage example:
-    qb = SQLiteQueryHandler(cfg)
-    qb.add_conditions()
-    rows, columns = qb.execute_query()
-    qb.close()
+    def _fetch_season_rows(self, common_name: str, season: str, year_filter) -> List[sqlite3.Row]:
+        """Fetch the candidate pool for one species+season: species+season+year
+        ONLY. Nothing else (not is_primary/extends_border, not
+        num_components, not bbox) may narrow this pool, since it's what the
+        day_range baseline gets computed from."""
+        conditions = ["LOWER(TRIM(category_common_name)) = ?", "season = ?"]
+        params: List[Any] = [common_name.lower().strip(), season]
 
-# Example usage:
-if __name__ == "__main__":
-    main()
+        if year_filter:
+            years = [str(y) for y in year_filter]
+            placeholders = ", ".join("?" for _ in years)
+            # substr(datetime, 1, 4) reliably extracts the year from both
+            # datetime formats present in this db (EXIF and ISO both start
+            # with a 4-digit year).
+            conditions.append(f"substr(datetime, 1, 4) IN ({placeholders})")
+            params.extend(years)
+
+        query = f"SELECT * FROM {self.table_name} WHERE " + " AND ".join(conditions)
+        return self.conn.execute(query, params).fetchall()
+
+    @staticmethod
+    def _day_range_mode(day_range) -> Tuple[Optional[str], Any]:
+        """Validate day_range config and return (mode, value), or (None, None)
+        if left entirely blank (no date filtering)."""
+        if not day_range:
+            return None, None
+
+        last_days = day_range.get("last_days")
+        first_days = day_range.get("first_days")
+        trim_days = day_range.get("trim_days") or {}
+        trim_start = trim_days.get("start")
+        trim_end = trim_days.get("end")
+        trim_active = trim_start is not None or trim_end is not None
+
+        active_modes = [bool(x) for x in (last_days is not None, first_days is not None, trim_active)]
+        if sum(active_modes) > 1:
+            raise ValueError(
+                "day_range must use exactly one of last_days / first_days / trim_days, got: "
+                f"last_days={last_days!r}, first_days={first_days!r}, "
+                f"trim_days={{'start': {trim_start!r}, 'end': {trim_end!r}}}"
+            )
+
+        if last_days is not None:
+            return "last_days", last_days
+        if first_days is not None:
+            return "first_days", first_days
+        if trim_active:
+            return "trim_days", (trim_start or 0, trim_end or 0)
+        return None, None
+
+    @staticmethod
+    def _apply_day_range(rows: List[sqlite3.Row], mode: str, value: Any) -> List[sqlite3.Row]:
+        parsed = [(parse_datetime(row["datetime"]), row) for row in rows]
+        parsed = [(dt, row) for dt, row in parsed if dt is not None]
+        if not parsed:
+            return []
+
+        dts = [dt for dt, _ in parsed]
+        min_dt, max_dt = min(dts), max(dts)
+
+        if mode == "last_days":
+            window_start, window_end = max_dt - timedelta(days=value), max_dt
+        elif mode == "first_days":
+            window_start, window_end = min_dt, min_dt + timedelta(days=value)
+        else:  # trim_days
+            start_days, end_days = value
+            window_start = min_dt + timedelta(days=start_days)
+            window_end = max_dt - timedelta(days=end_days)
+
+        return [row for dt, row in parsed if window_start <= dt <= window_end]
+
+    @staticmethod
+    def _bbox_mode(bbox_cfg) -> Tuple[Optional[str], Any]:
+        """Validate estimated_bbox_area_cm2 config and return (mode, value),
+        or (None, None) if left entirely blank (no bbox filtering)."""
+        if not bbox_cfg:
+            return None, None
+
+        min_v = bbox_cfg.get("min")
+        max_v = bbox_cfg.get("max")
+        pct = bbox_cfg.get("percentile")
+
+        minmax_active = min_v is not None or max_v is not None
+        pct_active = pct is not None
+
+        if minmax_active and pct_active:
+            raise ValueError(
+                "estimated_bbox_area_cm2 must use exactly one of {min,max} or percentile, "
+                f"got min={min_v!r}, max={max_v!r}, percentile={pct!r}"
+            )
+        if minmax_active:
+            return "minmax", (min_v, max_v)
+        if pct_active:
+            return "percentile", pct
+        return None, None
+
+    @staticmethod
+    def _apply_bbox_filter(rows: List[sqlite3.Row], mode: Optional[str], value: Any) -> List[sqlite3.Row]:
+        if mode is None or not rows:
+            return rows
+
+        if mode == "minmax":
+            min_v, max_v = value
+
+            def within_range(row: sqlite3.Row) -> bool:
+                area = row["estimated_bbox_area_cm2"]
+                if area is None:
+                    return False
+                if min_v is not None and area < min_v:
+                    return False
+                if max_v is not None and area > max_v:
+                    return False
+                return True
+
+            return [row for row in rows if within_range(row)]
+
+        # percentile
+        areas = sorted(
+            row["estimated_bbox_area_cm2"] for row in rows if row["estimated_bbox_area_cm2"] is not None
+        )
+        if not areas:
+            return []
+        threshold = percentile(areas, value)
+        return [
+            row for row in rows
+            if row["estimated_bbox_area_cm2"] is not None and row["estimated_bbox_area_cm2"] > threshold
+        ]
+
+    @staticmethod
+    def _apply_num_components_filter(rows: List[sqlite3.Row], num_components_cfg) -> List[sqlite3.Row]:
+        if not num_components_cfg:
+            return rows
+        min_v = num_components_cfg.get("min")
+        max_v = num_components_cfg.get("max")
+        if min_v is None and max_v is None:
+            return rows
+
+        def within_range(row: sqlite3.Row) -> bool:
+            n = row["num_components"]
+            if n is None:
+                return False
+            if min_v is not None and n < min_v:
+                return False
+            if max_v is not None and n > max_v:
+                return False
+            return True
+
+        return [row for row in rows if within_range(row)]
+
+    # ---- main entry point ----
+
+    def fetch_all(self) -> List[Dict[str, Any]]:
+        """Fetch filtered rows for every species in species_filters, applying
+        each species' own season/year/day_range/num_components/bbox
+        filters, and return the combined pool of rows as plain dicts."""
+        all_rows: List[Dict[str, Any]] = []
+
+        for common_name, spec in self.species_filters.items():
+            spec = spec or {}
+            season_filter = spec.get("season")
+            year_filter = spec.get("year")
+            seasons = list(season_filter) if season_filter else self._seasons_for_species(common_name)
+
+            day_mode, day_value = self._day_range_mode(spec.get("day_range"))
+            bbox_mode, bbox_value = self._bbox_mode(spec.get("estimated_bbox_area_cm2"))
+            num_components_cfg = spec.get("num_components")
+            is_primary = self._resolve_species_override(spec.get("is_primary"), self.morphological.get("is_primary"))
+            extends_border = self._resolve_species_override(
+                spec.get("extends_border"), self.morphological.get("extends_border")
+            )
+
+            species_kept = 0
+            for season in seasons:
+                rows = self._fetch_season_rows(common_name, season, year_filter)
+                fetched = len(rows)
+
+                if day_mode:
+                    rows = self._apply_day_range(rows, day_mode, day_value)
+                after_day_range = len(rows)
+
+                rows = self._apply_global_morphological_filters(rows, is_primary, extends_border)
+                after_morphological = len(rows)
+
+                rows = self._apply_num_components_filter(rows, num_components_cfg)
+                after_num_components = len(rows)
+
+                rows = self._apply_bbox_filter(rows, bbox_mode, bbox_value)
+
+                log.info(
+                    "%s / %s: fetched=%d -> day_range=%d -> morphological=%d -> num_components=%d -> bbox=%d",
+                    common_name, season, fetched, after_day_range, after_morphological, after_num_components, len(rows),
+                )
+
+                species_kept += len(rows)
+                all_rows.extend(dict(row) for row in rows)
+
+            log.info("Species '%s': %d rows kept across %d season(s).", common_name, species_kept, len(seasons))
+
+        return all_rows
+
+
+def main(cfg: DictConfig) -> List[Dict[str, Any]]:
+    engine = SpeciesFilterQueryEngine(cfg)
+    try:
+        rows = engine.fetch_all()
+        log.info("Fetched %d total rows across all species.", len(rows))
+        return rows
+    finally:
+        engine.close()


### PR DESCRIPTION
The goal of this PR is per species cutout filtering for recipe generation. 
Cutout selection for synthetic recipe generation moves from one shared filter set applied uniformly to every species, to per species filter configuration. Each species can now define its own selection criteria independently.

Filters available:
season / year: restrict a species to specific season(s)/year(s)
estimated_bbox_area_cm2: absolute {min, max} or a percentile threshold
num_components
day_range: date window relative to that species own observed date range for the season: last_days, first_days, or trim_days{start,end}
is_primary / extends_border: support of global and per species filtering both

